### PR TITLE
Refactored `configmanager.js` to use `app.getPath('appData')` for det…

### DIFF
--- a/app/assets/js/configmanager.js
+++ b/app/assets/js/configmanager.js
@@ -6,14 +6,16 @@ const { retry } = require('./util')
 
 const logger = LoggerUtil.getLogger('ConfigManager')
 
-const sysRoot = process.env.APPDATA || (process.platform == 'darwin' ? process.env.HOME + '/Library/Application Support' : process.env.HOME)
+const app = (process.type === 'renderer'
+    ? require('@electron/remote').app
+    : require('electron').app
+)
+
+const sysRoot = process.platform === 'linux' ? app.getPath('home') : app.getPath('appData')
 
 const dataPath = path.join(sysRoot, '.foxford')
 
-const launcherDir = (process.type === 'renderer'
-    ? require('@electron/remote').app
-    : require('electron').app
-).getPath('userData')
+const launcherDir = app.getPath('userData')
 
 /**
  * Retrieve the absolute path of the launcher directory.


### PR DESCRIPTION
…ermining the user's data directory.

This change replaces a platform-specific implementation that was prone to errors when usernames contained non-standard characters, especially on macOS.

By using Electron's built-in `app.getPath()` method, the application can now reliably resolve the correct data path on all supported operating systems (Windows, macOS, and Linux), ensuring proper functionality for all users, regardless of their username.