### PR TITLE
fix(crash-handler): handle missing version json with ENONET error

### DIFF
--- a/app/assets/js/crash-handler.js
+++ b/app/assets/js/crash-handler.js
@@ -54,5 +54,16 @@ exports.analyzeLog = function(logContent) {
         };
     }
 
+    // Check for missing version json file (ENOENT)
+    const missingVersionJsonRegex = /ENOENT: no such file or directory, open '.*[\\/]versions[\\/](.+)[\\/]\1\.json'/;
+    match = missingVersionJsonRegex.exec(logContent);
+    if (match && match[1]) {
+        return {
+            type: 'missing-version-file',
+            file: match[1] + '.json',
+            description: "Файл версии поврежден. Нажми 'Исправить' для восстановления."
+        };
+    }
+
     return null;
 }

--- a/app/assets/js/processbuilder.js
+++ b/app/assets/js/processbuilder.js
@@ -204,26 +204,40 @@ class ProcessBuilder {
 
                     // Button 1 Handler
                     setOverlayHandler(() => {
-                        const configPath = path.join(this.gameDir, 'config', crashAnalysis.file);
-                        if (fs.existsSync(configPath)) {
-                            try {
-                                const disabledPath = configPath + '.disabled';
-                                if (fs.existsSync(disabledPath)) fs.unlinkSync(disabledPath);
-                                fs.renameSync(configPath, disabledPath);
-                                logger.info(`Disabled corrupted config: ${configPath}`);
-                            } catch (err) {
-                                logger.error('Failed to disable config file', err);
+                        if (crashAnalysis.type === 'missing-version-file') {
+                            const versionPath = path.join(this.commonDir, 'versions', path.basename(crashAnalysis.file, '.json'));
+                            if (fs.existsSync(versionPath)) {
+                                try {
+                                    fs.removeSync(versionPath);
+                                    logger.info(`Deleted corrupted version directory: ${versionPath}`);
+                                } catch (err) {
+                                    logger.error('Failed to delete version directory', err);
+                                }
                             }
-                        }
-                        toggleOverlay(false);
+                            toggleOverlay(false);
+                            // No auto-restart for this type as it requires re-download/validation which is triggered by "Play"
+                        } else {
+                            const configPath = path.join(this.gameDir, 'config', crashAnalysis.file);
+                            if (fs.existsSync(configPath)) {
+                                try {
+                                    const disabledPath = configPath + '.disabled';
+                                    if (fs.existsSync(disabledPath)) fs.unlinkSync(disabledPath);
+                                    fs.renameSync(configPath, disabledPath);
+                                    logger.info(`Disabled corrupted config: ${configPath}`);
+                                } catch (err) {
+                                    logger.error('Failed to disable config file', err);
+                                }
+                            }
+                            toggleOverlay(false);
 
-                        setTimeout(() => {
-                            const launchBtn = document.getElementById('launch_button');
-                            if (launchBtn) {
-                                logger.info('Autostarting game after fix...');
-                                launchBtn.click();
-                            }
-                        }, 1000);
+                            setTimeout(() => {
+                                const launchBtn = document.getElementById('launch_button');
+                                if (launchBtn) {
+                                    logger.info('Autostarting game after fix...');
+                                    launchBtn.click();
+                                }
+                            }, 1000);
+                        }
                     });
 
                     // Button 2 Handler

--- a/tests/unit/app/assets/js/crash-handler.test.js
+++ b/tests/unit/app/assets/js/crash-handler.test.js
@@ -1,0 +1,51 @@
+const CrashHandler = require('@app/assets/js/crash-handler');
+
+describe('CrashHandler', () => {
+
+    it('should detect corrupted TOML config files', () => {
+        const log = 'Some log\nException loading config file example.toml\nMore log';
+        const result = CrashHandler.analyzeLog(log);
+        expect(result).toEqual({
+            type: 'corrupted-config',
+            file: 'example.toml',
+            description: 'The configuration file example.toml appears to be corrupted.'
+        });
+    });
+
+    it('should detect corrupted .cfg files', () => {
+        const log = 'Some log\nConfiguration file example.cfg is corrupt\nMore log';
+        const result = CrashHandler.analyzeLog(log);
+        expect(result).toEqual({
+            type: 'corrupted-config',
+            file: 'example.cfg',
+            description: 'The configuration file example.cfg appears to be corrupted.'
+        });
+    });
+
+    it('should detect corrupted .json files (JsonSyntaxException)', () => {
+        const log = 'Some log\ncom.google.gson.JsonSyntaxException: ... path/to/example.json\nMore log';
+        const result = CrashHandler.analyzeLog(log);
+        expect(result).toEqual({
+            type: 'corrupted-config',
+            file: 'example.json',
+            description: 'The configuration file example.json appears to be corrupted.'
+        });
+    });
+
+    it('should detect missing version json file (ENOENT)', () => {
+        const log = "ENOENT: no such file or directory, open 'C:\\Users\\Dns11\\AppData\\Roaming\\.foxford\\common\\versions\\1.20.1-fabric-0.16.10\\1.20.1-fabric-0.16.10.json'";
+        const result = CrashHandler.analyzeLog(log);
+        expect(result).toEqual({
+            type: 'missing-version-file',
+            file: '1.20.1-fabric-0.16.10.json',
+            description: "Файл версии поврежден. Нажми 'Исправить' для восстановления."
+        });
+    });
+
+    it('should return null for unknown errors', () => {
+        const log = 'Some random error\nSomething went wrong';
+        const result = CrashHandler.analyzeLog(log);
+        expect(result).toBeNull();
+    });
+
+});


### PR DESCRIPTION
- Added detection for `ENOENT: no such file or directory, open '.../versions/NAME/NAME.json'` error in `crash-handler.js`.
- Implemented auto-repair logic in `processbuilder.js` to delete the corrupted version directory, triggering a re-download on next launch.
- Added unit tests for the new crash detection logic.