### PR TITLE
Refactor crash handler to read log file tail instead of buffering output

### DIFF
--- a/app/assets/js/crash-handler.js
+++ b/app/assets/js/crash-handler.js
@@ -2,59 +2,100 @@ const fs = require('fs-extra');
 const path = require('path');
 
 /**
+ * Reads the last N bytes of a file.
+ * @param {string} filePath Path to the file.
+ * @param {number} maxBytes Number of bytes to read from the end.
+ * @returns {Promise<string>} The file content (tail).
+ */
+async function readLastBytes(filePath, maxBytes = 1024 * 200) { 
+    try {
+        if (!await fs.pathExists(filePath)) return '';
+        
+        const stats = await fs.stat(filePath);
+        const fileSize = stats.size;
+        if (fileSize === 0) return '';
+
+        const start = Math.max(0, fileSize - maxBytes);
+        const length = fileSize - start;
+        const buffer = Buffer.alloc(length);
+
+        const fd = await fs.open(filePath, 'r');
+        let bytesRead = 0;
+        try {
+            const res = await fs.read(fd, buffer, 0, length, start);
+            bytesRead = res.bytesRead !== undefined ? res.bytesRead : res; 
+        } finally {
+            await fs.close(fd);
+        }
+
+        const content = buffer.toString('utf-8', 0, bytesRead);
+        console.log(`[CrashHandler] Read ${bytesRead} bytes from log.`);
+        return content;
+    } catch (error) {
+        console.error(`[CrashHandler] Failed to read log file tail: ${error.message}`);
+        return '';
+    }
+}
+
+/**
  * Analyzes the game's log content for known crash patterns.
- *
  * @param {string} logContent The content of the latest.log file.
  * @returns {object | null} An object with crash details, or null if no known pattern is found.
  */
 exports.analyzeLog = function(logContent) {
     let match;
 
-    // Check for corrupted TOML config files
-    const corruptedTomlRegex = /(?:Exception|Failed) loading config file ([\w.-]+\.toml)/;
-    match = corruptedTomlRegex.exec(logContent);
-    if (match && match[1]) {
-        return {
-            type: 'corrupted-config',
-            file: match[1],
-            description: `The configuration file ${match[1]} appears to be corrupted.`
-        };
-    }
-
-    // Check for corrupted .cfg files
-    const corruptedCfgRegex = /Configuration file (.+)\.cfg is corrupt/;
-    match = corruptedCfgRegex.exec(logContent);
-    if (match && match[1]) {
-        return {
-            type: 'corrupted-config',
-            file: match[1] + '.cfg',
-            description: `The configuration file ${match[1]}.cfg appears to be corrupted.`
-        };
-    }
-
-    // Check for corrupted .json files
-    const corruptedJsonRegex = /com\.google\.gson\.JsonSyntaxException:.*?([a-zA-Z0-9_.-]+\.json)/;
-    match = corruptedJsonRegex.exec(logContent);
+    // 1. Config Loading Exception (Specific & Generic)
+    // Matches: "ModConfig$ConfigLoadingException: ... farmersdelight-client.toml"
+    // Regex logic: Find "ConfigLoadingException" OR "Failed loading config", 
+    // then ignore everything until the first .toml filename found (that doesn't have spaces).
+    const configErrorRegex = /(?:ConfigLoadingException|Failed loading config file).*?([^\s]+\.toml)/i;
+    match = configErrorRegex.exec(logContent);
     if (match && match[1]) {
         return {
             type: 'corrupted-config',
             file: path.basename(match[1]),
-            description: `The configuration file ${path.basename(match[1])} appears to be corrupted.`
-        };
-    }
-    
-    // Check for corrupted .properties files
-    const corruptedPropertiesRegex = /Invalid config file (.+)\.properties/;
-    match = corruptedPropertiesRegex.exec(logContent);
-    if (match && match[1]) {
-        return {
-            type: 'corrupted-config',
-            file: match[1] + '.properties',
-            description: `The configuration file ${match[1]}.properties appears to be corrupted.`
+            description: `Ошибка загрузки конфига: ${path.basename(match[1])}`
         };
     }
 
-    // Check for missing version json file (ENOENT)
+    // 2. MalformedInputException (Encoding/Null bytes error)
+    // Scan specifically for this java error, then look backwards for the last mentioned TOML file.
+    if (logContent.includes('MalformedInputException') || logContent.includes('ParsingException')) {
+        const errorIdx = logContent.indexOf('MalformedInputException');
+        // If specific error not found, try generic parsing exception location
+        const searchEndIdx = errorIdx !== -1 ? errorIdx : logContent.indexOf('ParsingException');
+
+        if (searchEndIdx !== -1) {
+            // Check text ONLY before the error to find the culprit file
+            const contentBeforeError = logContent.substring(0, searchEndIdx);
+            // Regex: capture any string ending in .toml that doesn't contain spaces
+            const tomlMatches = [...contentBeforeError.matchAll(/([^\s]+\.toml)/gi)];
+            
+            if (tomlMatches.length > 0) {
+                // Get the very last toml file mentioned before the crash
+                const culpritFile = tomlMatches[tomlMatches.length - 1][1];
+                return {
+                    type: 'corrupted-config',
+                    file: path.basename(culpritFile),
+                    description: `Файл ${path.basename(culpritFile)} поврежден (ошибка кодировки/парсинга).`
+                };
+            }
+        }
+    }
+
+    // 3. Generic "is corrupt" message
+    const corruptedCfgRegex = /Configuration file\s+.*?([^\s]+\.(?:cfg|toml|json))\s+is corrupt/i;
+    match = corruptedCfgRegex.exec(logContent);
+    if (match && match[1]) {
+        return {
+            type: 'corrupted-config',
+            file: path.basename(match[1]),
+            description: `Файл конфигурации ${path.basename(match[1])} поврежден.`
+        };
+    }
+
+    // 4. Missing version json file (ENOENT)
     const missingVersionJsonRegex = /ENOENT: no such file or directory, open '.*[\\/]versions[\\/](.+)[\\/]\1\.json'/;
     match = missingVersionJsonRegex.exec(logContent);
     if (match && match[1]) {
@@ -65,5 +106,51 @@ exports.analyzeLog = function(logContent) {
         };
     }
 
+    // 5. Incompatible Mods (Fabric/Quilt dependency errors)
+    // Matches: "net.fabricmc.loader.impl.FormattedException: Some of your mods are incompatible"
+    // OR: "[main/ERROR]: Incompatible mods found!"
+    if (logContent.includes('Incompatible mods found!') || 
+        logContent.includes('Some of your mods are incompatible') ||
+        logContent.includes('Mod resolution failed')) {
+        return {
+            type: 'incompatible-mods',
+            file: 'mods', // Условное имя, так как проблема во всей папке
+            description: "Несовместимые моды. Нажми 'Исправить', чтобы сбросить настройки модов."
+        };
+    }
+
     return null;
+}
+
+/**
+ * Analyzes a log file by reading its tail.
+ * @param {string} filePath Path to the log file.
+ * @returns {Promise<object | null>} Crash analysis result.
+ */
+exports.analyzeFile = async function(filePath) {
+    const content = await readLastBytes(filePath, 1024 * 200);
+    
+    if (!content) {
+        console.warn('[CrashHandler] Log file was empty or unreadable at crash time.');
+        return null;
+    }
+    
+    const result = exports.analyzeLog(content);
+    
+    if (result) {
+        console.log('[CrashHandler] Analysis success:', result);
+    } else {
+        console.log('[CrashHandler] Analysis returned null.');
+        
+        // DEBUG: Print what we see around the word "Exception" to understand why regex failed
+        const debugIdx = content.indexOf('Exception');
+        if (debugIdx !== -1) {
+            const start = Math.max(0, debugIdx - 300);
+            const end = Math.min(content.length, debugIdx + 300);
+            console.log('[CrashHandler DEBUG] Context around "Exception":\n', content.substring(start, end));
+        } else {
+             console.log('[CrashHandler DEBUG] No "Exception" word found in the last 200KB of log.');
+        }
+    }
+    return result;
 }

--- a/tests/unit/app/assets/js/crash-handler.test.js
+++ b/tests/unit/app/assets/js/crash-handler.test.js
@@ -1,51 +1,143 @@
 const CrashHandler = require('@app/assets/js/crash-handler');
+const fs = require('fs-extra');
+
+// Mock fs-extra
+jest.mock('fs-extra');
 
 describe('CrashHandler', () => {
 
-    it('should detect corrupted TOML config files', () => {
-        const log = 'Some log\nException loading config file example.toml\nMore log';
-        const result = CrashHandler.analyzeLog(log);
-        expect(result).toEqual({
-            type: 'corrupted-config',
-            file: 'example.toml',
-            description: 'The configuration file example.toml appears to be corrupted.'
+    // Reset mocks before each test
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('analyzeLog (synchronous)', () => {
+        it('should detect corrupted TOML config files', () => {
+            const log = 'Some log\nException loading config file example.toml\nMore log';
+            const result = CrashHandler.analyzeLog(log);
+            expect(result).toEqual({
+                type: 'corrupted-config',
+                file: 'example.toml',
+                description: 'The configuration file example.toml appears to be corrupted.'
+            });
+        });
+
+        it('should detect corrupted .cfg files', () => {
+            const log = 'Some log\nConfiguration file example.cfg is corrupt\nMore log';
+            const result = CrashHandler.analyzeLog(log);
+            expect(result).toEqual({
+                type: 'corrupted-config',
+                file: 'example.cfg',
+                description: 'The configuration file example.cfg appears to be corrupted.'
+            });
+        });
+
+        it('should detect corrupted .json files (JsonSyntaxException)', () => {
+            const log = 'Some log\ncom.google.gson.JsonSyntaxException: ... path/to/example.json\nMore log';
+            const result = CrashHandler.analyzeLog(log);
+            expect(result).toEqual({
+                type: 'corrupted-config',
+                file: 'example.json',
+                description: 'The configuration file example.json appears to be corrupted.'
+            });
+        });
+
+        it('should detect missing version json file (ENOENT)', () => {
+            const log = "ENOENT: no such file or directory, open 'C:\\Users\\Dns11\\AppData\\Roaming\\.foxford\\common\\versions\\1.20.1-fabric-0.16.10\\1.20.1-fabric-0.16.10.json'";
+            const result = CrashHandler.analyzeLog(log);
+            expect(result).toEqual({
+                type: 'missing-version-file',
+                file: '1.20.1-fabric-0.16.10.json',
+                description: "Файл версии поврежден. Нажми 'Исправить' для восстановления."
+            });
+        });
+
+        it('should return null for unknown errors', () => {
+            const log = 'Some random error\nSomething went wrong';
+            const result = CrashHandler.analyzeLog(log);
+            expect(result).toBeNull();
         });
     });
 
-    it('should detect corrupted .cfg files', () => {
-        const log = 'Some log\nConfiguration file example.cfg is corrupt\nMore log';
-        const result = CrashHandler.analyzeLog(log);
-        expect(result).toEqual({
-            type: 'corrupted-config',
-            file: 'example.cfg',
-            description: 'The configuration file example.cfg appears to be corrupted.'
-        });
-    });
+    describe('analyzeFile (asynchronous with partial read)', () => {
+        const filePath = '/mock/path/to/latest.log';
 
-    it('should detect corrupted .json files (JsonSyntaxException)', () => {
-        const log = 'Some log\ncom.google.gson.JsonSyntaxException: ... path/to/example.json\nMore log';
-        const result = CrashHandler.analyzeLog(log);
-        expect(result).toEqual({
-            type: 'corrupted-config',
-            file: 'example.json',
-            description: 'The configuration file example.json appears to be corrupted.'
-        });
-    });
+        it('should read the file tail and detect crash', async () => {
+            const crashLog = 'Some log content\nException loading config file corrupted.toml\nEnd of log';
+            const fileSize = 2000;
+            const buffer = Buffer.from(crashLog);
 
-    it('should detect missing version json file (ENOENT)', () => {
-        const log = "ENOENT: no such file or directory, open 'C:\\Users\\Dns11\\AppData\\Roaming\\.foxford\\common\\versions\\1.20.1-fabric-0.16.10\\1.20.1-fabric-0.16.10.json'";
-        const result = CrashHandler.analyzeLog(log);
-        expect(result).toEqual({
-            type: 'missing-version-file',
-            file: '1.20.1-fabric-0.16.10.json',
-            description: "Файл версии поврежден. Нажми 'Исправить' для восстановления."
-        });
-    });
+            // Mock fs.stat
+            fs.stat.mockResolvedValue({ size: fileSize });
 
-    it('should return null for unknown errors', () => {
-        const log = 'Some random error\nSomething went wrong';
-        const result = CrashHandler.analyzeLog(log);
-        expect(result).toBeNull();
+            // Mock fs.open
+            const fd = 123;
+            fs.open.mockResolvedValue(fd);
+
+            // Mock fs.read
+            fs.read.mockImplementation(async (fd, buf, offset, length, position) => {
+                // Mimic reading content into buffer
+                buffer.copy(buf);
+                return { bytesRead: buffer.length, buffer: buf };
+            });
+
+            // Mock fs.close
+            fs.close.mockResolvedValue();
+
+            const result = await CrashHandler.analyzeFile(filePath);
+
+            expect(fs.stat).toHaveBeenCalledWith(filePath);
+            expect(fs.open).toHaveBeenCalledWith(filePath, 'r');
+            // Should verify that fs.read was called. Argument verification for buffers is tricky but we can check calls.
+            expect(fs.read).toHaveBeenCalled();
+            expect(fs.close).toHaveBeenCalledWith(fd);
+
+            expect(result).toEqual({
+                type: 'corrupted-config',
+                file: 'corrupted.toml',
+                description: 'The configuration file corrupted.toml appears to be corrupted.'
+            });
+        });
+
+        it('should handle small files correctly (read entire file)', async () => {
+            const content = "Short log";
+            const fileSize = content.length;
+
+            fs.stat.mockResolvedValue({ size: fileSize });
+            fs.open.mockResolvedValue(123);
+            fs.read.mockImplementation(async (fd, buf) => {
+                const len = Buffer.from(content).copy(buf);
+                return { bytesRead: len, buffer: buf };
+            });
+            fs.close.mockResolvedValue();
+
+            const result = await CrashHandler.analyzeFile(filePath);
+            expect(fs.read).toHaveBeenCalled();
+            expect(result).toBeNull(); // "Short log" has no crash
+        });
+
+        it('should handle empty files', async () => {
+            fs.stat.mockResolvedValue({ size: 0 });
+
+            const result = await CrashHandler.analyzeFile(filePath);
+
+            expect(fs.open).not.toHaveBeenCalled();
+            expect(result).toBeNull();
+        });
+
+        it('should gracefully handle file read errors', async () => {
+            fs.stat.mockRejectedValue(new Error('File not found'));
+
+            // Mock console.error to keep test output clean
+            const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+            const result = await CrashHandler.analyzeFile(filePath);
+
+            expect(result).toBeNull();
+            expect(consoleSpy).toHaveBeenCalled();
+
+            consoleSpy.mockRestore();
+        });
     });
 
 });


### PR DESCRIPTION
This change removes the memory-intensive log ring buffer from ProcessBuilder.